### PR TITLE
The installation script creates a file called 1

### DIFF
--- a/aura-service-install.sh
+++ b/aura-service-install.sh
@@ -4,7 +4,7 @@
 #########################################
 
 read -p "Enter aura service account: " username
-getent passwd $username > /dev/null 2&>1
+getent passwd $username > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
   echo "Invalid username"


### PR DESCRIPTION
That is due a Typo, it should be 2>&1   instead of   2&>1 that creates a file called 1